### PR TITLE
Update composer.json to avoid psr-4 complaints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "type": "magento2-module",
     "autoload": {
-        "psr-4": {"[Ebolution\\GraphQlTranslation\\]":""},
+        "psr-4": {"[Ebolution\\GraphQlTranslation\\]\\":""},
         "files": ["registration.php"]
     },
     "license": [


### PR DESCRIPTION
When trying to install with composer it outputs this error:
```
[InvalidArgumentException]
psr-4 namespaces must end with a namespace separator, '[Ebolution\GraphQlTranslation\]' does not, use '[Ebolution\GraphQlTranslation\]\'.
```

Adding an escaped trailing slash in autoload solve this error.

Thank you for this plugin, it indeed helped us a lot!